### PR TITLE
[ENG-4518] Mount pod template files in spark operator pod using config map

### DIFF
--- a/charts/spark-operator-chart/pod-templates/delta-streamer-driver.yaml
+++ b/charts/spark-operator-chart/pod-templates/delta-streamer-driver.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Pod
+spec:
+  priorityClassName: delta-streamer-driver-priority-class

--- a/charts/spark-operator-chart/pod-templates/delta-streamer-executor.yaml
+++ b/charts/spark-operator-chart/pod-templates/delta-streamer-executor.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Pod
+spec:
+  priorityClassName: delta-streamer-exec-priority-class

--- a/charts/spark-operator-chart/pod-templates/metrics-pod-template.yaml
+++ b/charts/spark-operator-chart/pod-templates/metrics-pod-template.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Pod
+spec:
+  priorityClassName: metrics-job-priority-class

--- a/charts/spark-operator-chart/pod-templates/table-service-monitor-pod-template.yaml
+++ b/charts/spark-operator-chart/pod-templates/table-service-monitor-pod-template.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Pod
+spec:
+  priorityClassName: table-service-health-priority-class

--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -88,11 +88,18 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-      {{- if .Values.webhook.enable }}
         volumeMounts:
+          - name: pod-templates
+            mountPath: /etc/pod-templates/
+        {{- if .Values.webhook.enable }}
           - name: webhook-certs
             mountPath: /etc/webhook-certs
+        {{- end }}
       volumes:
+        - name: pod-templates
+          configMap:
+            name: pod-templates
+      {{- if .Values.webhook.enable }}
         - name: webhook-certs
           secret:
             secretName: {{ include "spark-operator.fullname" . }}-webhook-certs

--- a/charts/spark-operator-chart/templates/pod-templates-config-map.yaml
+++ b/charts/spark-operator-chart/templates/pod-templates-config-map.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-templates
+data:
+  {{- (.Files.Glob "pod-templates/**.yaml").AsConfig | nindent 4 }}


### PR DESCRIPTION
In order to make sure that metrics jobs are reliably run on dataplane, we want to use higher priority class for these jobs compared to other spark jobs. To apply a priority class to driver/executor pods, we need to use pod template files ([reference](https://spark.apache.org/docs/latest/running-on-kubernetes.html#priority-scheduling)) and these template files should be referred in the respective spark jobs ([reference](https://spark.apache.org/docs/latest/running-on-kubernetes.html#pod-template)). These template files should be present in the operator pod which initiates the driver pod creation. In this scenario, we're using config map to create a volume mount on the operator pod with these pod template files.

For more information, please refer this [ticket](https://app.clickup.com/t/18029943/ENG-4518).