### PR TITLE
[ENG-22581] Emit logs in json format in production mode

### DIFF
--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -322,11 +322,15 @@ func setupLog() {
 				config = zap.NewProductionEncoderConfig()
 			} else {
 				config = zap.NewDevelopmentEncoderConfig()
+				config.EncodeLevel = zapcore.CapitalColorLevelEncoder
 			}
-			config.EncodeLevel = zapcore.CapitalColorLevelEncoder
 			config.EncodeTime = zapcore.ISO8601TimeEncoder
 			config.EncodeCaller = zapcore.ShortCallerEncoder
-			o.Encoder = zapcore.NewConsoleEncoder(config)
+			if !development {
+				o.Encoder = zapcore.NewJSONEncoder(config)
+			} else {
+				o.Encoder = zapcore.NewConsoleEncoder(config)
+			}
 		}),
 	)
 }

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -339,11 +339,15 @@ func setupLog() {
 				config = zap.NewProductionEncoderConfig()
 			} else {
 				config = zap.NewDevelopmentEncoderConfig()
+				config.EncodeLevel = zapcore.CapitalColorLevelEncoder
 			}
-			config.EncodeLevel = zapcore.CapitalColorLevelEncoder
 			config.EncodeTime = zapcore.ISO8601TimeEncoder
 			config.EncodeCaller = zapcore.ShortCallerEncoder
-			o.Encoder = zapcore.NewConsoleEncoder(config)
+			if !development {
+				o.Encoder = zapcore.NewJSONEncoder(config)
+			} else {
+				o.Encoder = zapcore.NewConsoleEncoder(config)
+			}
 		}),
 	)
 }


### PR DESCRIPTION
## Purpose of this PR
This is an issue in OSS as well https://github.com/kubeflow/spark-operator/issues/2254

- Emit logs in json format in production mode with colour encoder not set
- Testing: Logs coming in json format in aws-acme org
![image](https://github.com/user-attachments/assets/014592d8-1180-4b24-90ea-710f5f31c5de)


## Change Category
Indicate the type of change by marking the applicable boxes:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->


## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

