### PR TITLE
[ENG-12547] Delete dangling spark resources in pending rerun state

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -408,6 +408,11 @@ func (r *Reconciler) reconcilePendingRerunSparkApplication(ctx context.Context, 
 			app := old.DeepCopy()
 
 			logger.Info("Pending rerun SparkApplication", "name", app.Name, "namespace", app.Namespace, "state", app.Status.AppState.State)
+			// delete any pending resources & then perform validation on resouce deletion
+			if err := r.deleteSparkResources(ctx, app); err != nil {
+				logger.Error(err, "failed to delete spark resources", "name", app.Name, "namespace", app.Namespace)
+				return err
+			}
 			if r.validateSparkResourceDeletion(ctx, app) {
 				logger.Info("Successfully deleted resources associated with SparkApplication", "name", app.Name, "namespace", app.Namespace, "state", app.Status.AppState.State)
 				r.recordSparkApplicationEvent(app)


### PR DESCRIPTION
## Purpose of this PR
We have seen scenarios where spark application is stuck in `PENDING_RERUN` state. In this state, if any spark resources like spark-ui-service or spark-ui-ingress are not deleted (but the driver pod is deleted), the application would not go be submitted again. So explicitly deleting any such resources would solve the problem of submitting the spark application from `PENDING_RERUN` state.

**Proposed changes:**
- Explicitly delete spark resources in `PENDING_RERUN` state before verifying the status of them.

## Testing

- Created & deployed adhoc image in aws-acme org.
- Reduced replicas of spark-operator-controller to 0.
- Deleted driver pod.
- Increased replicas of spark-operator-controller to 1.
- verified the sparkapplication status change from `FAILING` to `PENDING_RERUN` to `SUBMITTED` to `RUNNING`.
- When sparkapplication status changed to `FAILING` , it automatically deleted the spark-ui-service using same `deleteSparkResources` method added in `reconcilePendingRerunSparkApplication`.

````
{"level":"info","ts":"2025-04-27T13:55:51.006Z","caller":"sparkapplication/controller.go:177","msg":"Reconciling SparkApplication","name":"managed-spark-job-72775454-53bc-4e23","namespace":"managed-spark-jobs","state":"FAILING"}
{"level":"info","ts":"2025-04-27T13:55:51.006Z","caller":"sparkapplication/controller.go:968","msg":"Deleting driver pod","name":"managed-spark-job-72775454-53bc-4e23-driver","namespace":"managed-spark-jobs"}
{"level":"info","ts":"2025-04-27T13:55:51.011Z","caller":"sparkapplication/controller.go:989","msg":"Deleting Spark web UI service","name":"managed-spark-job-72775454-53bc-4e23-ui-svc","namespace":"managed-spark-jobs"}
{"level":"info","ts":"2025-04-27T13:55:51.047Z","caller":"sparkapplication/event_handler.go:188","msg":"SparkApplication updated","name":"managed-spark-job-72775454-53bc-4e23","namespace":"managed-spark-jobs","oldState":"FAILING","newState":"PENDING_RERUN"}
{"level":"info","ts":"2025-04-27T13:55:51.049Z","caller":"sparkapplication/controller.go:200","msg":"Finished reconciling SparkApplication","name":"managed-spark-job-72775454-53bc-4e23","namespace":"managed-spark-jobs"}
{"level":"info","ts":"2025-04-27T13:55:51.058Z","caller":"sparkapplication/controller.go:177","msg":"Reconciling SparkApplication","name":"managed-spark-job-72775454-53bc-4e23","namespace":"managed-spark-jobs","state":"PENDING_RERUN"}
{"level":"info","ts":"2025-04-27T13:55:51.058Z","caller":"sparkapplication/controller.go:410","msg":"Pending rerun SparkApplication","name":"managed-spark-job-72775454-53bc-4e23","namespace":"managed-spark-jobs","state":"PENDING_RERUN"}
{"level":"info","ts":"2025-04-27T13:55:51.058Z","caller":"sparkapplication/controller.go:968","msg":"Deleting driver pod","name":"managed-spark-job-72775454-53bc-4e23-driver","namespace":"managed-spark-jobs"}
{"level":"info","ts":"2025-04-27T13:55:51.062Z","caller":"sparkapplication/controller.go:989","msg":"Deleting Spark web UI service","name":"managed-spark-job-72775454-53bc-4e23-ui-svc","namespace":"managed-spark-jobs"}
{"level":"info","ts":"2025-04-27T13:55:51.167Z","caller":"sparkapplication/controller.go:417","msg":"Successfully deleted resources associated with SparkApplication","name":"managed-spark-job-72775454-53bc-4e23","namespace":"managed-spark-jobs","state":"PENDING_RERUN"}
{"level":"info","ts":"2025-04-27T13:55:51.167Z","caller":"sparkapplication/controller.go:653","msg":"Submitting SparkApplication","name":"managed-spark-job-72775454-53bc-4e23","namespace":"managed-spark-jobs","state":"PENDING_RERUN"}
{"level":"info","ts":"2025-04-27T13:55:51.186Z","caller":"sparkapplication/controller.go:701","msg":"Created web UI service for SparkApplication","name":"managed-spark-job-72775454-53bc-4e23","namespace":"managed-spark-jobs"}
{"level":"info","ts":"2025-04-27T13:55:51.186Z","caller":"sparkapplication/controller.go:761","msg":"Running spark-submit for SparkApplication","name":"managed-spark-job-72775454-53bc-4e23","namespace":"managed-spark-jobs","arguments":["--master","k8s://https://172.20.0.1:443","--deploy-mode","cluster","--class","com.onehouse.hudi.OnehouseDeltaStreamer","--name","managed-spark-job-72775454-53bc-4e23","--conf","spark.kubernetes.namespace=managed-spark-jobs","--conf","spark.kubernetes.container.image=onehouse/onehouse-spark:HUDI-1.114.0.DATAPLANE-1.77.0","--conf","spark.kubernetes.container.image.pullPolicy=IfNotPresent","--conf","spark.kubernetes.container.image.pullSecrets=docker-hub-creds","--conf","spark.kubernetes.submission.waitAppCompletion=false","--conf","spark.serializer=org.apache.spark.serializer.KryoSerializer","--conf","spark.metrics.conf.*.sink.prometheusServlet.path=/metrics/prometheus","--conf","spark.rdd.compress=true","--conf","spark.kubernetes.driver.service.annotation.prometheus.io/port=8090","--conf","spark.sql.optimizer.nestedSchemaPruning.enabled=false","--conf","spark.kubernetes.driver.annotation.ad.datadoghq.com/spark-kubernetes-driver.checks={\"openmetrics\": {\"instances\": [{\"openmetrics_endpoint\": \"http://%%host%%:9091/metrics\",\"namespace\": \"onehouse\",\"metrics\": [\"ohds_*\"]}]}}","--conf","spark.scheduler.pool=default","--conf","spark.eventLog.rolling.maxFileSize=128m","--conf","spark.metrics.appStatusSource.enabled=true","--conf","spark.kryoserializer.buffer.max=128m","--conf","spark.kubernetes.executor.label.yunikorn.apache.org/app-id=managed-spark-job-72775454-53bc-4e23","--conf","spark.checkpoint.compress=true","--conf","spark.metrics.namespace=onehouse","--conf","spark.ui.prometheus.enabled=true","--conf","spark.kubernetes.executor.label.yunikorn.apache.org/queue=root.e29eda62-1da0-4fce-9764-bf16c9a9c374","--conf","spark.dynamicAllocation.cachedExecutorIdleTimeout=3600s","--conf","spark.metrics.conf.master.sink.prometheusServlet.path=/metrics/master/prometheus","--conf","spark.eventLog.enabled=true","--conf","spark.kubernetes.driver.label.yunikorn.apache.org/app-id=managed-spark-job-72775454-53bc-4e23-driver","--conf","spark.sql.parquet.datetimeRebaseModeInWrite=CORRECTED","--conf","spark.kubernetes.driver.service.annotation.prometheus.io/path=/metrics/prometheus/","--conf","spark.memory.fraction=0.3","--conf","spark.sql.avro.datetimeRebaseModeInWrite=CORRECTED","--conf","spark.kubernetes.driver.label.scrape-metrics=true","--conf","spark.kubernetes.driver.label.yunikorn.apache.org/queue=root.e29eda62-1da0-4fce-9764-bf16c9a9c374","--conf","spark.dynamicAllocation.executorIdleTimeout=15s","--conf","spark.eventLog.compress=true","--conf","spark.kubernetes.driver.annotation.prometheus.io/port=8090","--conf","spark.dynamicAllocation.shuffleTracking.enabled=true","--conf","spark.kubernetes.executor.missingPodDetectDelta=120s","--conf","spark.scheduler.mode=FAIR","--conf","spark.kubernetes.memoryOverheadFactor=0.35","--conf","spark.executor.failuresValidityInterval=1","--conf","spark.driver.extraJavaOptions=-Dlog4j.configuration=file:///opt/spark/ds-log4j.properties -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/dumps/ds-onehouse/{{.Values.namespace}}-test.hprof","--conf","spark.kubernetes.driver.podTemplateFile=/etc/pod-templates/delta-streamer-driver.yaml","--conf","spark.network.timeout=800","--conf","spark.kubernetes.executor.podTemplateFile=/etc/pod-templates-v2/delta-streamer-executor-managed-spark-job-72775454-53bc-4e23.yaml","--conf","spark.kubernetes.driver.annotation.prometheus.io/path=/metrics/executors/prometheus/","--conf","spark.dynamicAllocation.executorAllocationRatio=0.5","--conf","spark.eventLog.rolling.enabled=true","--conf","spark.dynamicAllocation.sustainedSchedulerBacklogTimeout=60s","--conf","spark.scheduler.allocation.file=file:///opt/spark/fairscheduler.xml","--conf","spark.dynamicAllocation.schedulerBacklogTimeout=60s","--conf","spark.metrics.conf.applications.sink.prometheusServlet.path=/metrics/applications/prometheus","--conf","spark.memory.storageFraction=0.5","--conf","spark.streaming.kafka.consumer.poll.ms=30000","--conf","spark.kubernetes.driver.annotation.cluster-autoscaler.kubernetes.io/safe-to-evict=true","--conf","spark.executor.extraJavaOptions=-XX:+UseG1GC -XX:+UseCompressedOops -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/dumps/ds-onehouse/managed-spark-jobs.hprof -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxDirectMemorySize=1024m -XX:InitiatingHeapOccupancyPercent=25  -Dlog4j.configuration=file:///opt/spark/ds-log4j.properties","--conf","spark.eventLog.dir=s3a://onehouse-customer-bucket-b6d29292/spark-history-server/managed-spark-jobs","--conf","spark.metrics.conf.*.source.jvm.class=org.apache.spark.metrics.source.JvmSource","--conf","spark.executor.memoryOverheadFactor=0.35","--conf","spark.metrics.conf.*.sink.prometheusServlet.class=org.apache.spark.metrics.sink.PrometheusServlet","--conf","spark.network.maxRemoteBlockSizeFetchToMem=128m","--conf","spark.kubernetes.driver.annotation.prometheus.io/scrape=true","--conf","spark.dynamicAllocation.shuffleTracking.timeout=3600s","--conf","spark.kubernetes.driver.service.annotation.prometheus.io/scrape=true","--conf","spark.streaming.kafka.allowNonConsecutiveOffsets=true","--conf","spark.kubernetes.executor.annotation.cluster-autoscaler.kubernetes.io/safe-to-evict=true","--conf","spark.eventLog.compression.codec=snappy","--conf","spark.hadoop.parquet.avro.write-old-list-structure=false","--conf","spark.hadoop.fs.s3a.threads.max=100","--conf","spark.hadoop.hive.metastore.client.socket.timeout=180s","--conf","spark.hadoop.fs.s3a.path.style.access=false","--conf","spark.hadoop.hive.hmshandler.retry.attempts=5","--conf","spark.hadoop.fs.s3a.aws.credentials.provider=com.amazonaws.auth.InstanceProfileCredentialsProvider","--conf","spark.hadoop.fs.s3a.block.size=128m","--conf","spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem","--conf","spark.hadoop.fs.s3a.connection.maximum=5000","--conf","spark.kubernetes.driver.pod.name=managed-spark-job-72775454-53bc-4e23-driver","--conf","spark.kubernetes.driver.label.sparkoperator.k8s.io/app-name=managed-spark-job-72775454-53bc-4e23","--conf","spark.kubernetes.driver.label.sparkoperator.k8s.io/launched-by-spark-operator=true","--conf","spark.kubernetes.driver.label.sparkoperator.k8s.io/mutated-by-spark-operator=true","--conf","spark.kubernetes.driver.label.sparkoperator.k8s.io/submission-id=5b479a2f-4545-4a74-a11a-d4acc9047d7d","--conf","spark.kubernetes.driver.container.image=onehouse/onehouse-spark:HUDI-1.114.0.DATAPLANE-1.77.0","--conf","spark.driver.cores=2","--conf","spark.kubernetes.driver.request.cores=1800m","--conf","spark.kubernetes.driver.limit.cores=2000m","--conf","spark.driver.memory=4g","--conf","spark.kubernetes.authenticate.driver.serviceAccountName=managed-spark-jobs-spark","--conf","spark.kubernetes.driver.label.app.kubernetes.io/managed-by=Helm","--conf","spark.kubernetes.driver.label.orgId=0c043996-9e42-4904-95b9-f98918ebeda4","--conf","spark.kubernetes.driver.label.version=3.1.1","--conf","spark.kubernetes.driver.label.cloudProvider=AWS","--conf","spark.kubernetes.driver.label.customerBucket=onehouse-customer-bucket-b6d29292","--conf","spark.kubernetes.executor.label.sparkoperator.k8s.io/app-name=managed-spark-job-72775454-53bc-4e23","--conf","spark.kubernetes.executor.label.sparkoperator.k8s.io/launched-by-spark-operator=true","--conf","spark.kubernetes.executor.label.sparkoperator.k8s.io/mutated-by-spark-operator=true","--conf","spark.kubernetes.executor.label.sparkoperator.k8s.io/submission-id=5b479a2f-4545-4a74-a11a-d4acc9047d7d","--conf","spark.kubernetes.executor.container.image=onehouse/onehouse-spark:HUDI-1.114.0.DATAPLANE-1.77.0","--conf","spark.executor.cores=2","--conf","spark.kubernetes.executor.request.cores=1200m","--conf","spark.kubernetes.executor.limit.cores=1800m","--conf","spark.executor.memory=4g","--conf","spark.kubernetes.executor.label.app.kubernetes.io/managed-by=Helm","--conf","spark.kubernetes.executor.label.customerBucket=onehouse-customer-bucket-b6d29292","--conf","spark.kubernetes.executor.label.orgId=0c043996-9e42-4904-95b9-f98918ebeda4","--conf","spark.kubernetes.executor.label.version=3.1.1","--conf","spark.kubernetes.executor.label.cloudProvider=AWS","--conf","spark.dynamicAllocation.enabled=true","--conf","spark.dynamicAllocation.shuffleTracking.enabled=true","--conf","spark.dynamicAllocation.initialExecutors=0","--conf","spark.dynamicAllocation.minExecutors=0","--conf","spark.dynamicAllocation.maxExecutors=8","local:///opt/spark/onehouse-dataplane.jar","--job-uuid","managed-spark-job-72775454-53bc-4e23","--orgid","0c043996-9e42-4904-95b9-f98918ebeda4","--linkid","b6d29292-96c6-5f2a-a062-95885008836f","--cloud-provider","AWS","--region","us-west-2","--environment","staging","--cluster-id","e29eda62-1da0-4fce-9764-bf16c9a9c374","--namespace","managed-spark-jobs","--table-props-file","s3a://onehouse-customer-bucket-b6d29292/deltastreamer-table-configs/72775454-53bc-4e23/desired_job_state.properties","--table-props-jsonl-file","s3a://onehouse-customer-bucket-b6d29292/deltastreamer-table-configs/72775454-53bc-4e23/desired_job_state.jsonl","--sync-jobs-thread-pool","-1","--sts-embed-in-ds-mode","true","--sts-sync-interval-seconds","15","--sts-unblocked-scheduling-per-table","--retry-on-source-failures","--max-retry-count","10"]}
````

I couldn't figure out a way to reproduce the exact scenario where spark application status is in `PENDING_RERUN` state with `spark-ui-service` running.


## Change Category
Indicate the type of change by marking the applicable boxes:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->


## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

