### PR TITLE
[ENG-12547] Revert "Delete dangling spark resources in pending rerun state"

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -408,11 +408,6 @@ func (r *Reconciler) reconcilePendingRerunSparkApplication(ctx context.Context, 
 			app := old.DeepCopy()
 
 			logger.Info("Pending rerun SparkApplication", "name", app.Name, "namespace", app.Namespace, "state", app.Status.AppState.State)
-			// delete any pending resources & then perform validation on resouce deletion
-			if err := r.deleteSparkResources(ctx, app); err != nil {
-				logger.Error(err, "failed to delete spark resources", "name", app.Name, "namespace", app.Namespace)
-				return err
-			}
 			if r.validateSparkResourceDeletion(ctx, app) {
 				logger.Info("Successfully deleted resources associated with SparkApplication", "name", app.Name, "namespace", app.Namespace, "state", app.Status.AppState.State)
 				r.recordSparkApplicationEvent(app)


### PR DESCRIPTION
Reverts onehouseinc/spark-on-k8s-operator#11

this caused more issues than solved and we had to revert to 2.0.1.4-dev