### PR TITLE
Attempt fix of pending re-run stuck state in spark applications

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -408,6 +408,49 @@ func (r *Reconciler) reconcilePendingRerunSparkApplication(ctx context.Context, 
 			app := old.DeepCopy()
 
 			logger.Info("Pending rerun SparkApplication", "name", app.Name, "namespace", app.Namespace, "state", app.Status.AppState.State)
+
+			// Check if driver pod exists and is running. If so, sync the application state.
+			// This handles the case where the operator restarts and finds running pods
+			// with SparkApplications stuck in PENDING_RERUN state.
+			driverPodName := app.Status.DriverInfo.PodName
+			if driverPodName == "" {
+				driverPodName = util.GetDriverPodName(app)
+			}
+
+			driverPod := &corev1.Pod{}
+			err = r.client.Get(ctx, types.NamespacedName{Name: driverPodName, Namespace: app.Namespace}, driverPod)
+			if err == nil {
+				// Driver pod exists - check if it's running or pending
+				if driverPod.Status.Phase == corev1.PodRunning || driverPod.Status.Phase == corev1.PodPending {
+					logger.Info("Driver pod exists and is running/pending, syncing application state",
+						"name", app.Name, "namespace", app.Namespace, "podName", driverPod.Name, "podPhase", driverPod.Status.Phase)
+					// Update the driver info if it wasn't set
+					if app.Status.DriverInfo.PodName == "" {
+						app.Status.DriverInfo.PodName = driverPod.Name
+					}
+					// Preserve the start time and execution attempts from the pod's creation time
+					// since the application is already running
+					if app.Status.LastSubmissionAttemptTime.IsZero() {
+						app.Status.LastSubmissionAttemptTime = driverPod.CreationTimestamp
+					}
+					if app.Status.ExecutionAttempts == 0 {
+						// We don't know the exact number of attempts, but at least 1
+						app.Status.ExecutionAttempts = 1
+					}
+					// Sync the application state to match the actual pod state
+					if err := r.updateSparkApplicationState(ctx, app); err != nil {
+						logger.Error(err, "Failed to sync application state from running pod", "name", app.Name, "namespace", app.Namespace)
+						// Continue with normal flow even if sync fails
+					}
+				} else {
+					logger.Info("Driver pod exists but is not running/pending",
+						"name", app.Name, "namespace", app.Namespace, "podPhase", driverPod.Status.Phase)
+				}
+			} else if !errors.IsNotFound(err) {
+				logger.Error(err, "Failed to get driver pod", "name", driverPodName, "namespace", app.Namespace)
+			}
+
+			// If resources are deleted, proceed with normal resubmission flow
 			if r.validateSparkResourceDeletion(ctx, app) {
 				logger.Info("Successfully deleted resources associated with SparkApplication", "name", app.Name, "namespace", app.Namespace, "state", app.Status.AppState.State)
 				r.recordSparkApplicationEvent(app)

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -550,6 +550,248 @@ var _ = Describe("SparkApplication Controller", func() {
 			Expect(app.Status.ExecutorState).To(HaveLen(1))
 		})
 	})
+
+	Context("When reconciling a pending rerun SparkApplication with running driver pod", func() {
+		ctx := context.Background()
+		appName := "test-pending-rerun"
+		appNamespace := "default"
+		key := types.NamespacedName{
+			Name:      appName,
+			Namespace: appNamespace,
+		}
+
+		BeforeEach(func() {
+			By("Creating a test SparkApplication in pending rerun state")
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      appName,
+						Namespace: appNamespace,
+					},
+					Spec: v1beta2.SparkApplicationSpec{
+						MainApplicationFile: util.StringPtr("local:///dummy.jar"),
+					},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+				// Create a running driver pod (simulating operator restart scenario)
+				driverPod := createDriverPod(appName, appNamespace)
+				Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+				driverPod.Status.Phase = corev1.PodRunning
+				Expect(k8sClient.Status().Update(ctx, driverPod)).To(Succeed())
+
+				// Set app to pending rerun with no start time or attempts
+				app.Status.AppState.State = v1beta2.ApplicationStatePendingRerun
+				app.Status.DriverInfo.PodName = driverPod.Name
+				app.Status.LastSubmissionAttemptTime = metav1.Time{} // Empty time
+				app.Status.ExecutionAttempts = 0
+				Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+
+			By("Deleting the created test SparkApplication")
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+
+			By("Deleting the driver pod")
+			driverPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
+		})
+
+		It("Should preserve start time and execution attempts from running driver pod", func() {
+			By("Reconciling the pending rerun SparkApplication")
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(3),
+				nil,
+				sparkapplication.Options{Namespaces: []string{appNamespace}},
+			)
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+
+			// Verify that start time was set from pod creation time
+			Expect(app.Status.LastSubmissionAttemptTime.IsZero()).To(BeFalse())
+
+			// Verify that execution attempts was set to 1
+			Expect(app.Status.ExecutionAttempts).To(Equal(int32(1)))
+
+			// Verify state transitioned to running
+			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStateRunning))
+		})
+	})
+
+	Context("When reconciling a pending rerun SparkApplication with pending driver pod", func() {
+		ctx := context.Background()
+		appName := "test-pending-rerun-pending-pod"
+		appNamespace := "default"
+		key := types.NamespacedName{
+			Name:      appName,
+			Namespace: appNamespace,
+		}
+
+		BeforeEach(func() {
+			By("Creating a test SparkApplication in pending rerun state")
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      appName,
+						Namespace: appNamespace,
+					},
+					Spec: v1beta2.SparkApplicationSpec{
+						MainApplicationFile: util.StringPtr("local:///dummy.jar"),
+					},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+				// Create a pending driver pod
+				driverPod := createDriverPod(appName, appNamespace)
+				Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+				driverPod.Status.Phase = corev1.PodPending
+				Expect(k8sClient.Status().Update(ctx, driverPod)).To(Succeed())
+
+				// Set app to pending rerun with no start time or attempts
+				app.Status.AppState.State = v1beta2.ApplicationStatePendingRerun
+				app.Status.DriverInfo.PodName = driverPod.Name
+				app.Status.LastSubmissionAttemptTime = metav1.Time{} // Empty time
+				app.Status.ExecutionAttempts = 0
+				Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+
+			By("Deleting the created test SparkApplication")
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+
+			By("Deleting the driver pod")
+			driverPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
+		})
+
+		It("Should preserve start time and execution attempts from pending driver pod", func() {
+			By("Reconciling the pending rerun SparkApplication")
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(3),
+				nil,
+				sparkapplication.Options{Namespaces: []string{appNamespace}},
+			)
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+
+			// Verify that start time was set from pod creation time
+			Expect(app.Status.LastSubmissionAttemptTime.IsZero()).To(BeFalse())
+
+			// Verify that execution attempts was set to 1
+			Expect(app.Status.ExecutionAttempts).To(Equal(int32(1)))
+		})
+	})
+
+	Context("When reconciling a pending rerun SparkApplication with failed driver pod", func() {
+		ctx := context.Background()
+		appName := "test-pending-rerun-failed-pod"
+		appNamespace := "default"
+		key := types.NamespacedName{
+			Name:      appName,
+			Namespace: appNamespace,
+		}
+
+		BeforeEach(func() {
+			By("Creating a test SparkApplication in pending rerun state")
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      appName,
+						Namespace: appNamespace,
+					},
+					Spec: v1beta2.SparkApplicationSpec{
+						MainApplicationFile: util.StringPtr("local:///dummy.jar"),
+					},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+				// Create a failed driver pod (terminal state)
+				driverPod := createDriverPod(appName, appNamespace)
+				Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+				driverPod.Status.Phase = corev1.PodFailed
+				Expect(k8sClient.Status().Update(ctx, driverPod)).To(Succeed())
+
+				// Set app to pending rerun with no start time or attempts
+				app.Status.AppState.State = v1beta2.ApplicationStatePendingRerun
+				app.Status.DriverInfo.PodName = driverPod.Name
+				app.Status.LastSubmissionAttemptTime = metav1.Time{} // Empty time
+				app.Status.ExecutionAttempts = 0
+				Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+
+			By("Deleting the created test SparkApplication")
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+
+			By("Deleting the driver pod if it exists")
+			driverPod := &corev1.Pod{}
+			if err := k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod); err == nil {
+				Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
+			}
+		})
+
+		It("Should not preserve start time when driver pod is in failed state", func() {
+			By("Reconciling the pending rerun SparkApplication")
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(3),
+				nil,
+				sparkapplication.Options{Namespaces: []string{appNamespace}},
+			)
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+
+			// When driver pod is in failed state, the normal pending rerun flow should proceed
+			// This means the app should remain in pending rerun state (waiting for pod deletion)
+			// and should NOT have preserved the start time or execution attempts from the failed pod
+			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStatePendingRerun))
+
+			// Start time and execution attempts should remain empty/zero since the pod is failed
+			// and needs to be cleaned up before resubmission
+			Expect(app.Status.LastSubmissionAttemptTime.IsZero()).To(BeTrue())
+			Expect(app.Status.ExecutionAttempts).To(Equal(int32(0)))
+		})
+	})
 })
 
 func getDriverNamespacedName(appName string, appNamespace string) types.NamespacedName {


### PR DESCRIPTION
## Purpose of this PR

When the spark operator starts up and it sees spark applications in pending re-run it doesn't resolve these.

This will handle that case to prevent the states being stuck at "pending-rerun"

## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist
Before submitting your PR, please review the following:

- [ ] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

