### PR TITLE
[ENG-35525] fix new spark app submission

### DIFF
--- a/pkg/common/metrics.go
+++ b/pkg/common/metrics.go
@@ -37,6 +37,8 @@ const (
 	MetricSparkApplicationStartLatencySeconds = "spark_application_start_latency_seconds"
 
 	MetricSparkApplicationStartLatencySecondsHistogram = "spark_application_start_latency_seconds_histogram"
+
+	MetricSparkApplicationOrphanedResourceCleanupCount = "spark_application_orphaned_resource_cleanup_count"
 )
 
 // Spark executor metric names.


### PR DESCRIPTION
### 🛑 Important:
Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!

For guidelines on how to contribute, please review the [CONTRIBUTING.md](CONTRIBUTING.md) document.

## Purpose of this PR

Bug fix of spark job submission not idempotent.

## Change Category
Indicate the type of change by marking the applicable boxes:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale


  When a Spark Operator controller pod is replaced by k8s (due to crash, rollout, or reschedule) when working on spark job submission , the "driver pod already exists" error occurs, causing submission failures.

  Root Cause

  Sequence of events:

  1. Old controller starts SparkApplication submission
  2. spark-submit creates driver pod successfully (pod enters Pending/Running state)
  3. Before the controller can update SparkApplication status to "Submitted" inside k8s registry, the controller pod terminates
  4. SparkApplication status remains in "New" state (enum toString is an empty string)
  5. New controller picks up the reconciliation
  6. Sees state="New", calls reconcileNewSparkApplication()
  7. This function submits without validating existing resources
  8. spark-submit attempts to create driver pod with the same name
  9. Kubernetes returns HTTP 409 Conflict → "driver pod already exists" error

  Example from open search logs:
  04:02:12.468 - Old controller (25m8q) creates driver pod "spark-code-715a4cc4-9321cfe3-driver" (Pending)
  04:02:12.627 - Old controller encounters "context canceled" and is terminated
  04:02:30.414 - New controller (x1jlx) creates SparkApplication (state still "New")
  04:02:30.420 - New controller creates driver pod (but same name!)
  04:02:35.941 - Error: "failed to run spark-submit: driver pod already exist"

<img width="3840" height="1764" alt="image" src="https://github.com/user-attachments/assets/368782b9-ca36-4e26-80d9-bee3cb06be5b" />


  Code issue:
  - reconcileNewSparkApplication (controller.go:252-278) assumes "New" applications start with a clean slate
  - It submits directly without checking for orphaned resources
  - In contrast, reconcileFailedSubmissionSparkApplication (line 333) does call validateSparkResourceDeletion before resubmission

  Solution

  Add defensive validation to reconcileNewSparkApplication:

  1. Check for orphaned resources before submission using existing validateSparkResourceDeletion function
  2. Clean up orphaned resources if found (driver pod, service, ingress)
  3. Requeue to wait for Kubernetes garbage collection
  4. Add Prometheus metric (spark_application_orphaned_resource_cleanup_count) to track frequency
  5. Enhanced logging to provide visibility into orphaned resource detection

  This follows the same pattern already used in reconcileFailedSubmissionSparkApplication, making it a low-risk defensive fix.

  Impact

  - Self-healing for controller failover scenarios
  - No breaking changes or API modifications
  - Minimal performance impact (3 additional API calls only for "New" state applications)
  - Provides observability through metrics to detect controller instability

## Checklist
Before submitting your PR, please review the following:

- [ ] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detects and cleans up orphaned Spark resources before submitting new applications to avoid conflicts.

* **Bug Fixes**
  * Prevents submission failures (HTTP 409) caused by leftover resources by performing cleanup-and-retry.

* **Tests**
  * Added end-to-end tests covering various orphaned-resource scenarios and expected reconciliation behavior.

* **Chores**
  * Added a metric to track orphaned-resource cleanup frequency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->