### PR TITLE
Upgrade Hadoop jars to 3.4.2 for Azure workload support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,17 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/* && \
     # Create directories
     mkdir -p $SPARK_HOME/jars /etc/k8s-webhook-server/serving-certs /home/spark && \
-    # Download all JARs in parallel for better performance
+    # Upgrade Hadoop jars from 3.3.4 (bundled with Spark 3.5.3) to 3.4.2
+    rm -f $SPARK_HOME/jars/hadoop-client-api-3.3.4.jar \
+          $SPARK_HOME/jars/hadoop-client-runtime-3.3.4.jar \
+          $SPARK_HOME/jars/hadoop-shaded-guava-1.1.1.jar && \
+    wget -q -O $SPARK_HOME/jars/hadoop-client-api-3.4.2.jar \
+        https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-client-api/3.4.2/hadoop-client-api-3.4.2.jar && \
+    wget -q -O $SPARK_HOME/jars/hadoop-client-runtime-3.4.2.jar \
+        https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-client-runtime/3.4.2/hadoop-client-runtime-3.4.2.jar && \
+    wget -q -O $SPARK_HOME/jars/hadoop-shaded-guava-1.4.0.jar \
+        https://repo1.maven.org/maven2/org/apache/hadoop/thirdparty/hadoop-shaded-guava/1.4.0/hadoop-shaded-guava-1.4.0.jar && \
+    # Download additional JARs
     wget -q -O $SPARK_HOME/jars/hadoop-aws-3.1.1.jar \
         https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.1.1/hadoop-aws-3.1.1.jar && \
     wget -q -O $SPARK_HOME/jars/aws-java-sdk-bundle-1.11.814.jar \
@@ -61,8 +71,8 @@ RUN set -ex; \
         https://repo1.maven.org/maven2/org/apache/spark/spark-avro_2.12/3.1.1/spark-avro_2.12-3.1.1.jar && \
     wget -q -O $SPARK_HOME/jars/gcs-connector-hadoop3-latest.jar \
         https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar && \
-    wget -q -O $SPARK_HOME/jars/hadoop-azure-3.3.4.jar \
-        https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar && \
+    wget -q -O $SPARK_HOME/jars/hadoop-azure-3.4.2.jar \
+        https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.4.2/hadoop-azure-3.4.2.jar && \
     wget -q -O $SPARK_HOME/jars/azure-storage-blob-12.25.0.jar \
         https://repo1.maven.org/maven2/com/azure/azure-storage-blob/12.25.0/azure-storage-blob-12.25.0.jar && \
     wget -q -O $SPARK_HOME/jars/azure-core-1.51.0.jar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,16 +55,19 @@ RUN set -ex; \
     # Upgrade Hadoop jars from 3.3.4 (bundled with Spark 3.5.3) to 3.4.2
     rm -f $SPARK_HOME/jars/hadoop-client-api-3.3.4.jar \
           $SPARK_HOME/jars/hadoop-client-runtime-3.3.4.jar \
-          $SPARK_HOME/jars/hadoop-shaded-guava-1.1.1.jar && \
+          $SPARK_HOME/jars/hadoop-shaded-guava-1.1.1.jar \
+          $SPARK_HOME/jars/hadoop-yarn-server-web-proxy-3.3.4.jar && \
     wget -q -O $SPARK_HOME/jars/hadoop-client-api-3.4.2.jar \
         https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-client-api/3.4.2/hadoop-client-api-3.4.2.jar && \
     wget -q -O $SPARK_HOME/jars/hadoop-client-runtime-3.4.2.jar \
         https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-client-runtime/3.4.2/hadoop-client-runtime-3.4.2.jar && \
     wget -q -O $SPARK_HOME/jars/hadoop-shaded-guava-1.4.0.jar \
         https://repo1.maven.org/maven2/org/apache/hadoop/thirdparty/hadoop-shaded-guava/1.4.0/hadoop-shaded-guava-1.4.0.jar && \
+    wget -q -O $SPARK_HOME/jars/hadoop-yarn-server-web-proxy-3.4.2.jar \
+        https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-yarn-server-web-proxy/3.4.2/hadoop-yarn-server-web-proxy-3.4.2.jar && \
     # Download additional JARs
-    wget -q -O $SPARK_HOME/jars/hadoop-aws-3.1.1.jar \
-        https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.1.1/hadoop-aws-3.1.1.jar && \
+    wget -q -O $SPARK_HOME/jars/hadoop-aws-3.4.2.jar \
+        https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.4.2/hadoop-aws-3.4.2.jar && \
     wget -q -O $SPARK_HOME/jars/aws-java-sdk-bundle-1.11.814.jar \
         https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.814/aws-java-sdk-bundle-1.11.814.jar && \
     wget -q -O $SPARK_HOME/jars/spark-avro_2.12-3.1.1.jar \
@@ -77,6 +80,8 @@ RUN set -ex; \
         https://repo1.maven.org/maven2/com/azure/azure-storage-blob/12.25.0/azure-storage-blob-12.25.0.jar && \
     wget -q -O $SPARK_HOME/jars/azure-core-1.51.0.jar \
         https://repo1.maven.org/maven2/com/azure/azure-core/1.51.0/azure-core-1.51.0.jar && \
+    wget -q -O $SPARK_HOME/jars/azure-xml-1.1.0.jar \
+        https://repo1.maven.org/maven2/com/azure/azure-xml/1.1.0/azure-xml-1.1.0.jar && \
     wget -q -O $SPARK_HOME/jars/azure-core-http-netty-1.15.3.jar \
         https://repo1.maven.org/maven2/com/azure/azure-core-http-netty/1.15.3/azure-core-http-netty-1.15.3.jar && \
     # Set permissions for all JARs at once

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,9 @@ RUN set -ex; \
         https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.4.2/hadoop-aws-3.4.2.jar && \
     wget -q -O $SPARK_HOME/jars/aws-java-sdk-bundle-1.11.814.jar \
         https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.814/aws-java-sdk-bundle-1.11.814.jar && \
+    # AWS SDK v2 bundle required by hadoop-aws 3.4.2 (v1 bundle kept for code still using com.amazonaws.* APIs)
+    wget -q -O $SPARK_HOME/jars/aws-sdk-v2-bundle-2.29.52.jar \
+        https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/2.29.52/bundle-2.29.52.jar && \
     wget -q -O $SPARK_HOME/jars/spark-avro_2.12-3.1.1.jar \
         https://repo1.maven.org/maven2/org/apache/spark/spark-avro_2.12/3.1.1/spark-avro_2.12-3.1.1.jar && \
     wget -q -O $SPARK_HOME/jars/gcs-connector-hadoop3-latest.jar \

--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,7 @@ go-lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
 .PHONY: unit-test
 unit-test: envtest ## Run unit tests.
 	@echo "Running unit tests..."
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)"
-	go test $(shell go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(shell go list ./... | grep -v /e2e) -coverprofile cover.out
 
 .PHONY: e2e-test
 e2e-test: envtest ## Run the e2e tests against a Kind k8s instance that is spun up.

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ KUSTOMIZE_VERSION ?= v5.4.1
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
 KIND_VERSION ?= v0.23.0
 KIND_K8S_VERSION ?= v1.29.3
-ENVTEST_VERSION ?= release-0.18
+ENVTEST_VERSION ?= release-0.19
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION ?= 1.29.3
 GOLANGCI_LINT_VERSION ?= v1.61.0


### PR DESCRIPTION
## Summary
- Upgrades `hadoop-azure` from 3.3.4 to 3.4.2
- Upgrades core Hadoop jars (`hadoop-client-api`, `hadoop-client-runtime`, `hadoop-shaded-guava`) from 3.3.4 to 3.4.2 to avoid version mismatch with hadoop-azure
- Removes old 3.3.4 jars from the base Spark 3.5.3 image before adding 3.4.2 replacements

## Test plan
- [ ] Build Docker image and verify all Hadoop jars are at 3.4.2
- [ ] Test Azure ABFSS connectivity with the upgraded jars
- [ ] Verify no `NoSuchMethodError` or `NoClassDefFoundError` at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded bundled Hadoop-related libraries in the runtime image for improved compatibility and stability.
  * Replaced an older shaded Guava with a newer release.
  * Updated Azure storage connector and added a related Azure XML artifact.
  * Added an updated Hadoop AWS artifact while retaining existing cloud connector jars.
  * Scoped the test environment variable to the unit-test invocation and bumped the test tooling default version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->